### PR TITLE
New release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Chart 0.0.17 [SingleSpace 2.14.2] - 2023-08-19
 ### Helm changes
 - New applications versions:
-    singlespace - 2.14.2
+    singlespace - 2.15.1
+    ingress - 0.1.0
 
+- Add `Role`, `RoleBinding` and `ServiceAccount` for singlespace appliction
+- Add new block for `serviceAccount`
+
+```
+      # Specifies whether a service account should be created
+      serviceAccount:
+        create: false
+        # You can provide your serviceAccount name to use, also set create to false
+        # name: ""
+        annotations: {}
+        # annotations:
+        # ## Enable if EKS IAM for SA is used
+        #   eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/my-role
+```
 
 ## Chart 0.0.16 [SingleSpace 2.14.0] - 2023-07-25
 ### Helm changes

--- a/charts/singlespace/Chart.yaml
+++ b/charts/singlespace/Chart.yaml
@@ -3,4 +3,4 @@ name: singlespace
 description: A Helm chart for SingleSpace
 type: application
 version: 0.0.17
-appVersion: 2.14.2
+appVersion: 2.15.1

--- a/charts/singlespace/templates/_helpers.tpl
+++ b/charts/singlespace/templates/_helpers.tpl
@@ -61,3 +61,15 @@ livenessProbe:
   successThreshold: 1
   failureThreshold: 3
 {{- end }}
+
+{{- define "sa-singlespace.serviceAccount" -}}
+{{- if .Values.global.sa.singlespace.serviceAccount }}
+{{- if .Values.global.sa.singlespace.serviceAccount.create }}
+{{ .Values.appName }}-serviceaccount
+{{- else if .Values.global.sa.singlespace.serviceAccount.name }}
+{{ .Values.global.sa.singlespace.serviceAccount.name }}
+{{- else }}
+""
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/singlespace/templates/deployment.yaml
+++ b/charts/singlespace/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ .Values.appName }}-deployment
   labels:
-{{- include "sa-singlespace.labels" . | nindent 4 }}
+    {{- include "sa-singlespace.labels" . | nindent 4 }}
 spec:
 {{- if .Values.global.sa.singlespace.autoscaling }}
 {{- if .Values.global.sa.singlespace.autoscaling.enabled }}
@@ -12,7 +12,7 @@ spec:
 {{- end }}
   selector:
     matchLabels:
-{{- include "sa-singlespace.labels" . | nindent 6 }}
+      {{- include "sa-singlespace.labels" . | nindent 6 }}
 {{- with .Values.global.deploymentStrategy }}
   strategy:
 {{ toYaml . | trim | indent 4 }}
@@ -27,13 +27,13 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
-{{- include "sa-singlespace.labels" . | nindent 8 }}
+        {{- include "sa-singlespace.labels" . | nindent 8 }}
     spec:
-  {{- if not (eq .Values.global.repotype "public") }}
+      {{- if not (eq .Values.global.repotype "public") }}
       imagePullSecrets:
         - name: {{ .Values.global.imagePullSecrets.name }}-{{ .Values.global.env | default "prod" }}
-  {{- end }}
-      serviceAccountName: ""
+      {{- end }}
+      serviceAccountName: {{- include "sa-singlespace.serviceAccount" . | nindent 8 }}
       securityContext:
         {{- toYaml .Values.global.sa.podSecurityContext | nindent 8 }}
       containers:

--- a/values.yaml
+++ b/values.yaml
@@ -108,3 +108,12 @@ global:
         requests:
           cpu: 100m
           memory: 200Mi
+      # Specifies whether a service account should be created
+      serviceAccount:
+        create: false
+        # You can provide your serviceAccount name to use, also set create to false
+        # name: ""
+        annotations: {}
+        # annotations:
+        # ## Enable if EKS IAM for SA is used
+        #   eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/my-role


### PR DESCRIPTION
## Chart 0.0.17 [SingleSpace 2.14.2] - 2023-08-19
### Helm changes
- New applications versions:
    singlespace - 2.15.1
    ingress - 0.1.0

- Add `Role`, `RoleBinding` and `ServiceAccount` for singlespace appliction
- Add new block for `serviceAccount`

```
      # Specifies whether a service account should be created
      serviceAccount:
        create: false
        # You can provide your serviceAccount name to use, also set create to false
        # name: ""
        annotations: {}
        # annotations:
        # ## Enable if EKS IAM for SA is used
        #   eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/my-role
```