### PR TITLE
New release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Chart 0.2.11 [SingleSpace 3.12.5] - 2024-09-30.
+### Helm changes
+- Applications versions:
+  - auth - 3.12.5
+  - workspace - 3.12.5
+  - frontend - 3.12.4
+  - ingress - 0.1.2
+- Add parameter `content_security_policy` in values file.
+- The minimum number of characters in the password has been increased
+
+
+## Chart 0.2.10 [SingleSpace 3.10.0] - 2024-07-31.
+### Helm changes
+- Applications versions:
+    - auth - 3.10.6
+    - workspace - 3.10.6
+    - frontend - 3.10.0
+    - ingress - 0.1.2
+- Add parameter `portMetrics` in values file, using for define port for metrics
+- Add monitoring for `auth`
+- Update monitoring manifest for `workspace`
+
+## Chart 0.2.9 [SingleSpace 3.10.0] - 2024-07-29.
+### Helm changes
+- New applications versions:
+    - auth - 3.10.6
+    - workspace - 3.10.6
+    - frontend - 3.10.0
+    - ingress - 0.1.2
+- Remove hardcode registry domain from sub-charts. Switch to `{{ .Values.global.imageRegistry }}`
+
 ## Chart 0.2.8 [SingleSpace 3.10.0] - 2024-07-08
 ### Helm changes
 - New applications versions:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,14 +3,14 @@ name: singlespace
 description: A Helm chart for Account
 icon: https://account.corezoid.com/static/logo.svg
 type: application
-version: 0.2.8
-appVersion: 3.10.0
+version: 0.2.11
+appVersion: 3.12.5
 dependencies:
   - name: account-auth
-    version: 0.1.11
+    version: 0.1.15
   - name: account-frontend
-    version: 0.1.10
+    version: 0.1.13
   - name: account-ingress
     version: 0.1.2
   - name: account-workspace
-    version: 0.1.11
+    version: 0.1.15

--- a/charts/account-auth/Chart.yaml
+++ b/charts/account-auth/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: account-auth
 description: A Helm chart for Account Auth
 type: application
-version: 0.1.11
-appVersion: 3.10.0
+version: 0.1.15
+appVersion: 3.12.5

--- a/charts/account-auth/templates/_helpers.tpl
+++ b/charts/account-auth/templates/_helpers.tpl
@@ -54,6 +54,13 @@ application: {{ include "module.auth.name" . }}
 {{- end -}}
 {{- end }}
 
+{{/*
+Set metrics port
+*/}}
+{{- define "account.auth.portMetricsNumber" -}}
+{{ .Values.global.account.auth.portMetrics | default 9100 }}
+{{- end }}
+
 {{- define "account.auth.portHttpName" -}}
 http
 {{- end }}
@@ -71,7 +78,7 @@ TCP
 Image url
 */}}
 {{- define "account.auth.imageUrl" -}}
-{{ .Values.image.registry }}/{{ .Values.global.repotype | default "public" }}/{{ .Values.image.repository }}:{{ .Values.global.account.auth.tag | default .Chart.AppVersion }}
+{{ .Values.global.imageRegistry }}/{{ .Values.global.repotype | default "public" }}/{{ .Values.image.repository }}:{{ .Values.global.account.auth.tag | default .Chart.AppVersion }}
 {{- end }}
 
 {{- define "account.auth.annotations" -}}

--- a/charts/account-auth/templates/configmap.yaml
+++ b/charts/account-auth/templates/configmap.yaml
@@ -15,6 +15,9 @@ data:
       type: port
       bind_ip: 0.0.0.0
       port: {{ .Values.global.account.auth.port }}
+      {{- if .Values.global.serviceMonitor }}
+      metrics_port: {{ include "account.auth.portMetricsNumber" . }}
+      {{- end }}
     psql:
       host: ${POSTGRES_DBHOST}
       port: ${POSTGRES_DBPORT}

--- a/charts/account-auth/templates/deployment.yaml
+++ b/charts/account-auth/templates/deployment.yaml
@@ -76,6 +76,11 @@ spec:
             - name: {{ include "account.auth.portHttpName" . }}
               containerPort: {{ include "account.auth.portNumber" . }}
               protocol: {{ include "account.auth.portProtocol" . }}
+            {{- if .Values.global.serviceMonitor }}
+            - name: metrics
+              containerPort: {{ include "account.auth.portMetricsNumber" . }}
+              protocol: {{ include "account.auth.portProtocol" . }}
+            {{- end }}
           {{- with $auth_data.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/account-auth/templates/monitoring.yaml
+++ b/charts/account-auth/templates/monitoring.yaml
@@ -5,15 +5,15 @@ kind: ServiceMonitor
 metadata:
   name: {{ .Values.appName }}
   labels:
-    {{- include "account.workspace.labels" . | nindent 4 }}
+    {{- include "account.auth.labels" . | nindent 4 }}
     {{- include "common.ServiceMonitor.metadata.labes" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      {{- include "account.workspace.labels" . | nindent 6 }}
+      {{- include "account.auth.labels" . | nindent 6 }}
   endpoints:
   - path: {{ .Values.prometheusPath | default "/metrics" }}
-    targetPort: {{ include "account.workspace.portMetricsNumber" . }}
+    targetPort: {{ include "account.auth.portMetricsNumber" . }}
     interval: {{ .Values.prometheusInterval | default "15s" }}
 {{- end -}}
 {{- end -}}

--- a/charts/account-auth/values.yaml
+++ b/charts/account-auth/values.yaml
@@ -1,7 +1,6 @@
 appName: account-auth
 
 image:
-  registry: docker-hub.middleware.biz
   repository: account-auth
 
 configPath: "/opt/conf"

--- a/charts/account-frontend/Chart.yaml
+++ b/charts/account-frontend/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 name: account-frontend
 description: A Helm chart for Account Frontend
 type: application
-version: 0.1.10
-appVersion: 3.10.0
+version: 0.1.13
+appVersion: 3.12.4

--- a/charts/account-frontend/templates/_helpers.tpl
+++ b/charts/account-frontend/templates/_helpers.tpl
@@ -71,7 +71,7 @@ TCP
 Image url
 */}}
 {{- define "account.frontend.imageUrl" -}}
-{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.image.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}/{{ else }}{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ end }}{{ .Values.image.repository }}:{{ .Values.global.account.frontend.tag  | default .Chart.AppVersion }}
+{{ .Values.global.imageRegistry }}/{{ .Values.global.repotype | default "public" }}/{{ .Values.image.repository }}:{{ .Values.global.account.frontend.tag | default .Chart.AppVersion }}
 {{- end }}
 
 {{- define "account.frontend.annotations" -}}

--- a/charts/account-frontend/templates/configmap.yaml
+++ b/charts/account-frontend/templates/configmap.yaml
@@ -67,11 +67,15 @@ data:
 
       add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
       add_header X-Content-Type-Options nosniff;
+      {{- if .Values.global.account.frontend.disable_sameorigin }}
+      #add_header X-Frame-Options SAMEORIGIN;
+      {{- else }}
       add_header X-Frame-Options SAMEORIGIN;
+      {{- end }}
       add_header X-XSS-Protection "1; mode=block";
       add_header 'Referrer-Policy' 'origin-when-cross-origin';
       add_header Permissions-Policy "geolocation=(), camera=()";
-      add_header Content-Security-Policy "default-src 'self' blob: 'unsafe-inline' 'unsafe-eval' data: https://unpkg.com wss://*.{{ .Values.global.env }}.{{ .Values.global.domain }} https://{{ .Values.global.account.subDomain}}.{{ .Values.global.domain }}  https://*.control.events https://img.icons8.com/ https://www.google-analytics.com https://fonts.gstatic.com https://www.googletagmanager.com https://*.{{ .Values.global.env }}.{{ .Values.global.domain }} https://github.com https://www.facebook.com https://appleid.apple.com https://*.ngrok-free.app https://*.google.com https://stats.g.doubleclick.net https://fonts.googleapis.com https://*.google.com.ua https://*.shopify.com https://shopify.com https://*.googleusercontent.com https://*.simulator.company;";
+      add_header Content-Security-Policy "default-src 'self' blob: 'unsafe-inline' 'unsafe-eval' data: {{- range .Values.global.account.content_security_policy.urls }} {{.}}{{- end }} https://unpkg.com wss://*.{{ .Values.global.env }}.{{ .Values.global.domain }} https://{{ .Values.global.account.subDomain}}.{{ .Values.global.domain }}  https://*.control.events https://img.icons8.com/ https://www.google-analytics.com https://fonts.gstatic.com https://www.googletagmanager.com https://*.{{ .Values.global.env }}.{{ .Values.global.domain }} https://github.com https://www.facebook.com https://appleid.apple.com https://*.ngrok-free.app https://*.google.com https://stats.g.doubleclick.net https://fonts.googleapis.com https://*.google.com.ua https://*.shopify.com https://shopify.com https://*.googleusercontent.com https://*.simulator.company; frame-ancestors 'self' https://{{ .Values.global.account.subDomain}}.{{ .Values.global.domain }} https://*.control.events https://*.simulator.company {{- range .Values.global.account.content_security_policy.urls }} {{.}}{{- end }};";
 
       location @redirect {
           return 302 /avatars/54x54/0.jpg;
@@ -85,11 +89,15 @@ data:
 
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
         add_header X-Content-Type-Options nosniff;
+        {{- if .Values.global.account.frontend.disable_sameorigin }}
+        #add_header X-Frame-Options SAMEORIGIN;
+        {{- else }}
         add_header X-Frame-Options SAMEORIGIN;
+        {{- end }}
         add_header X-XSS-Protection "1; mode=block";
         add_header 'Referrer-Policy' 'origin-when-cross-origin';
         add_header Permissions-Policy "geolocation=(), camera=()";
-        add_header Content-Security-Policy "default-src 'self' blob: 'unsafe-inline' 'unsafe-eval' data: https://unpkg.com wss://*.{{ .Values.global.env }}.{{ .Values.global.domain }} https://{{ .Values.global.account.subDomain}}.{{ .Values.global.domain }}  https://*.control.events https://img.icons8.com/ https://www.google-analytics.com https://fonts.gstatic.com https://www.googletagmanager.com https://*.{{ .Values.global.env }}.{{ .Values.global.domain }} https://github.com https://www.facebook.com https://appleid.apple.com https://*.ngrok-free.app https://*.google.com https://stats.g.doubleclick.net https://fonts.googleapis.com https://*.google.com.ua https://*.shopify.com https://shopify.com https://*.googleusercontent.com https://*.simulator.company;";
+        add_header Content-Security-Policy "default-src 'self' blob: 'unsafe-inline' 'unsafe-eval' data: {{- range .Values.global.account.content_security_policy.urls }} {{.}}{{- end }} https://unpkg.com wss://*.{{ .Values.global.env }}.{{ .Values.global.domain }} https://{{ .Values.global.account.subDomain}}.{{ .Values.global.domain }}  https://*.control.events https://img.icons8.com/ https://www.google-analytics.com https://fonts.gstatic.com https://www.googletagmanager.com https://*.{{ .Values.global.env }}.{{ .Values.global.domain }} https://github.com https://www.facebook.com https://appleid.apple.com https://*.ngrok-free.app https://*.google.com https://stats.g.doubleclick.net https://fonts.googleapis.com https://*.google.com.ua https://*.shopify.com https://shopify.com https://*.googleusercontent.com https://*.simulator.company; frame-ancestors 'self' https://{{ .Values.global.account.subDomain}}.{{ .Values.global.domain }} https://*.control.events https://*.simulator.company {{- range .Values.global.account.content_security_policy.urls }} {{.}}{{- end }};";
 
       }
 
@@ -109,38 +117,50 @@ data:
 
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
         add_header X-Content-Type-Options nosniff;
+        {{- if .Values.global.account.frontend.disable_sameorigin }}
+        #add_header X-Frame-Options SAMEORIGIN;
+        {{- else }}
         add_header X-Frame-Options SAMEORIGIN;
+        {{- end }}
         add_header X-XSS-Protection "1; mode=block";
         add_header 'Referrer-Policy' 'origin-when-cross-origin';
         add_header Permissions-Policy "geolocation=(), camera=()";
         {{- if .Values.global.simulator }}
         add_header 'Access-Control-Allow-Origin' 'https://{{ .Values.global.simulator.subDomain}}.{{ .Values.global.simulator.mainDomian }}';
         {{- end }}
-        add_header Content-Security-Policy "default-src 'self' blob: 'unsafe-inline' 'unsafe-eval' data: https://unpkg.com wss://*.{{ .Values.global.env }}.{{ .Values.global.domain }} https://{{ .Values.global.account.subDomain}}.{{ .Values.global.domain }}  https://*.control.events https://img.icons8.com/ https://www.google-analytics.com https://fonts.gstatic.com https://www.googletagmanager.com https://*.{{ .Values.global.env }}.{{ .Values.global.domain }} https://github.com https://www.facebook.com https://appleid.apple.com https://*.ngrok-free.app https://*.google.com https://stats.g.doubleclick.net https://fonts.googleapis.com https://*.google.com.ua https://*.shopify.com https://shopify.com https://*.googleusercontent.com https://*.simulator.company;";
+        add_header Content-Security-Policy "default-src 'self' blob: 'unsafe-inline' 'unsafe-eval' data: {{- range .Values.global.account.content_security_policy.urls }} {{.}}{{- end }} https://unpkg.com wss://*.{{ .Values.global.env }}.{{ .Values.global.domain }} https://{{ .Values.global.account.subDomain}}.{{ .Values.global.domain }}  https://*.control.events https://img.icons8.com/ https://www.google-analytics.com https://fonts.gstatic.com https://www.googletagmanager.com https://*.{{ .Values.global.env }}.{{ .Values.global.domain }} https://github.com https://www.facebook.com https://appleid.apple.com https://*.ngrok-free.app https://*.google.com https://stats.g.doubleclick.net https://fonts.googleapis.com https://*.google.com.ua https://*.shopify.com https://shopify.com https://*.googleusercontent.com https://*.simulator.company; frame-ancestors 'self' https://{{ .Values.global.account.subDomain}}.{{ .Values.global.domain }} https://*.control.events https://*.simulator.company {{- range .Values.global.account.content_security_policy.urls }} {{.}}{{- end }};";
 
       }
 
       location / {
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
         add_header X-Content-Type-Options nosniff;
+        {{- if .Values.global.account.frontend.disable_sameorigin }}
+        #add_header X-Frame-Options SAMEORIGIN;
+        {{- else }}
         add_header X-Frame-Options SAMEORIGIN;
+        {{- end }}
         add_header X-XSS-Protection "1; mode=block";
         add_header 'Referrer-Policy' 'origin-when-cross-origin';
         add_header Permissions-Policy "geolocation=(), camera=()";
-        add_header Content-Security-Policy "default-src 'self' blob: 'unsafe-inline' 'unsafe-eval' data: https://unpkg.com wss://*.{{ .Values.global.env }}.{{ .Values.global.domain }} https://{{ .Values.global.account.subDomain}}.{{ .Values.global.domain }} https://www.keycloak.org/ https://*.control.events https://img.icons8.com/ https://www.google-analytics.com https://fonts.gstatic.com https://www.googletagmanager.com https://*.{{ .Values.global.domain }} https://github.com https://www.facebook.com https://appleid.apple.com https://*.ngrok-free.app https://*.google.com https://stats.g.doubleclick.net https://fonts.googleapis.com https://*.google.com.ua https://*.shopify.com https://shopify.com https://*.googleusercontent.com https://*.simulator.company https://www.gstatic.com https://aadcdn.msauth.net;";
+        add_header Content-Security-Policy "default-src 'self' blob: 'unsafe-inline' 'unsafe-eval' data: {{- range .Values.global.account.content_security_policy.urls }} {{.}}{{- end }} https://unpkg.com wss://*.{{ .Values.global.env }}.{{ .Values.global.domain }} https://{{ .Values.global.account.subDomain}}.{{ .Values.global.domain }} https://www.keycloak.org/ https://*.control.events https://img.icons8.com/ https://www.google-analytics.com https://fonts.gstatic.com https://www.googletagmanager.com https://*.{{ .Values.global.domain }} https://github.com https://www.facebook.com https://appleid.apple.com https://*.ngrok-free.app https://*.google.com https://stats.g.doubleclick.net https://fonts.googleapis.com https://*.google.com.ua https://*.shopify.com https://shopify.com https://*.googleusercontent.com https://*.simulator.company https://www.gstatic.com https://aadcdn.msauth.net; frame-ancestors 'self' https://{{ .Values.global.account.subDomain}}.{{ .Values.global.domain }} https://*.control.events https://*.simulator.company {{- range .Values.global.account.content_security_policy.urls }} {{.}}{{- end }};";
         try_files $uri /index.html;
       }
 
-      location ~ ^/(api|auth|oauth2|download) {
+      location ~ ^/(api|auth|oauth2|download|pmi_lms) {
         proxy_pass http://{{ include "account.auth.service.name" . }}:{{ .Values.global.account.auth.port | default 80}};
         add_header Cache-Control "no-cache, must-revalidate";
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
         add_header X-Content-Type-Options nosniff;
+        {{- if .Values.global.account.frontend.disable_sameorigin }}
+        #add_header X-Frame-Options SAMEORIGIN;
+        {{- else }}
         add_header X-Frame-Options SAMEORIGIN;
+        {{- end }}
         add_header X-XSS-Protection "1; mode=block";
         add_header 'Referrer-Policy' 'origin-when-cross-origin';
         add_header Permissions-Policy "geolocation=(), camera=()";
-        add_header Content-Security-Policy "default-src 'self' blob: 'unsafe-inline' 'unsafe-eval' data: https://unpkg.com wss://*.{{ .Values.global.env }}.{{ .Values.global.domain }} https://{{ .Values.global.account.subDomain}}.{{ .Values.global.domain }} https://*.control.events https://img.icons8.com/ https://www.google-analytics.com https://fonts.gstatic.com https://www.googletagmanager.com https://*.{{ .Values.global.domain }} https://github.com https://www.facebook.com https://appleid.apple.com https://*.ngrok-free.app https://*.google.com https://stats.g.doubleclick.net https://fonts.googleapis.com https://*.google.com.ua https://*.shopify.com https://shopify.com https://*.googleusercontent.com https://*.simulator.company;";
+        add_header Content-Security-Policy "default-src 'self' blob: 'unsafe-inline' 'unsafe-eval' data: {{- range .Values.global.account.content_security_policy.urls }} {{.}}{{- end }} https://unpkg.com wss://*.{{ .Values.global.env }}.{{ .Values.global.domain }} https://{{ .Values.global.account.subDomain}}.{{ .Values.global.domain }} https://*.control.events https://img.icons8.com/ https://www.google-analytics.com https://fonts.gstatic.com https://www.googletagmanager.com https://*.{{ .Values.global.domain }} https://github.com https://www.facebook.com https://appleid.apple.com https://*.ngrok-free.app https://*.google.com https://stats.g.doubleclick.net https://fonts.googleapis.com https://*.google.com.ua https://*.shopify.com https://shopify.com https://*.googleusercontent.com https://*.simulator.company; frame-ancestors 'self'  https://{{ .Values.global.account.subDomain}}.{{ .Values.global.domain }} https://*.control.events https://*.simulator.company {{- range .Values.global.account.content_security_policy.urls }} {{.}}{{- end }};";
      }
 
       location ~ ^/(client|public|face|webhook) {

--- a/charts/account-frontend/values.yaml
+++ b/charts/account-frontend/values.yaml
@@ -1,5 +1,4 @@
 appName: account-frontend
 
 image:
-  registry: docker-hub.middleware.biz
   repository: account-frontend

--- a/charts/account-workspace/Chart.yaml
+++ b/charts/account-workspace/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: account-workspace
 description: A Helm chart for WorkSpace
 type: application
-version: 0.1.11
-appVersion: 3.10.0
+version: 0.1.15
+appVersion: 3.12.5

--- a/charts/account-workspace/templates/_helpers.tpl
+++ b/charts/account-workspace/templates/_helpers.tpl
@@ -66,12 +66,18 @@ application: {{ include "module.workspace.name" . }}
 {{- include "module.workspace.name" . }}-cpu-autoscale
 {{- end -}}
 
+{{/*
+Set metrics port
+*/}}
+{{- define "account.workspace.portMetricsNumber" -}}
+{{ .Values.global.account.workspace.portMetrics | default 9100 }}
+{{- end }}
 
 {{/*
 Image url
 */}}
 {{- define "account.workspace.imageUrl" -}}
-{{ .Values.image.registry }}/{{ .Values.global.repotype | default "public" }}/{{ .Values.image.repository }}:{{ .Values.global.account.workspace.tag | default .Chart.AppVersion }}
+{{ .Values.global.imageRegistry }}/{{ .Values.global.repotype | default "public" }}/{{ .Values.image.repository }}:{{ .Values.global.account.workspace.tag | default .Chart.AppVersion }}
 {{- end }}
 
 {{- define "account.workspace.annotations" -}}

--- a/charts/account-workspace/templates/configmap.yaml
+++ b/charts/account-workspace/templates/configmap.yaml
@@ -15,6 +15,9 @@ data:
       type: port
       bind_ip: 0.0.0.0
       port: {{ .Values.global.account.workspace.port }}
+      {{- if .Values.global.serviceMonitor }}
+      metrics_port: {{ include "account.workspace.portMetricsNumber" . }}
+      {{- end }}
     psql:
       host: ${POSTGRES_DBHOST}
       port: ${POSTGRES_DBPORT}
@@ -32,5 +35,4 @@ data:
       port: ${REDIS_PORT}
       password: ${REDIS_PASSWORD}
       database: ${REDIS_DB}
-
 {{ $global_config | toYaml | trim | indent 4 }}

--- a/charts/account-workspace/templates/deployment.yaml
+++ b/charts/account-workspace/templates/deployment.yaml
@@ -70,6 +70,11 @@ spec:
             - name: {{ include "account.workspace.portHttpName" . }}
               containerPort: {{ include "account.workspace.portNumber" . }}
               protocol: {{ include "account.workspace.portProtocol" . }}
+            {{- if .Values.global.serviceMonitor }}
+            - name: metrics
+              containerPort: {{ include "account.workspace.portMetricsNumber" . }}
+              protocol: {{ include "account.workspace.portProtocol" . }}
+            {{- end }}
           {{- with $workspace_data.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/account-workspace/values.yaml
+++ b/charts/account-workspace/values.yaml
@@ -1,7 +1,6 @@
 appName: workspace
 
 image:
-  registry: docker-hub.middleware.biz
   repository: account-workspace
 
 configPath: "/opt/conf"

--- a/mixins/dashboards/account-dashboard.json
+++ b/mixins/dashboards/account-dashboard.json
@@ -1,0 +1,999 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 50,
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "account"
+      ],
+      "targetBlank": false,
+      "title": "Account dashboards",
+      "type": "dashboards"
+    }
+  ],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 18,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": false,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "editorMode": "builder",
+          "expr": "{namespace=~\"$namespace\"} !~ `my_corezoid_0|http: named cookie not present|SpecifiedUserIsBlocked|AlreadyExist` | json | l = `E`",
+          "legendFormat": "{{err}}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Errors log",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 11,
+      "options": {
+        "displayLabels": [
+          "value"
+        ],
+        "legend": {
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by(err) (sum_over_time(errors_total{namespace=\"$namespace\", err!~\"my_corezoid_0|http: named cookie not present|SpecifiedUserIsBlocked|AlreadyExist|\"}[$__interval]))",
+          "format": "time_series",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{err}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Errors",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 0,
+        "y": 7
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sum by (type) (increase(inbound_request_duration_seconds_count{namespace=\"$namespace\", path=~\"$path\"}[$__rate_interval]))",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{type}} API",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Inbound RPM",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 9,
+        "y": 7
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "avg(rate(inbound_request_duration_seconds_sum{namespace=\"$namespace\",path=~\"$path\"}[1m])) by (type) / avg(rate(inbound_request_duration_seconds_count{namespace=\"$namespace\",path=~\"$path\"}[1m])) by (type)",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{type}} API",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Inbound Latency (ms)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 7
+      },
+      "id": 12,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.1.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (new_code) (\n  label_replace(\n    rate(inbound_request_duration_seconds_count{namespace=\"$namespace\",code=~'4..|5..'}[$__range]),\n    \"new_code\",\n    \"${1}xx\",\n    \"code\",\n    \"(^\\\\d).+\"\n  )\n) / \nscalar(sum(rate(inbound_request_duration_seconds_count{namespace=\"$namespace\"}[$__range]))) * 100",
+          "instant": false,
+          "legendFormat": "{{new_code}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Inbound Error codes percentage",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 9,
+        "x": 0,
+        "y": 15
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sum by (type,url) (increase(outbound_request_duration_seconds_count{namespace=\"$namespace\"}[$__rate_interval]))",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{type}}: {{url}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Outbound RPM",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 9,
+        "x": 9,
+        "y": 15
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "avg(rate(outbound_request_duration_seconds_sum{namespace=\"$namespace\"}[1m])) by (type,url) / avg(rate(outbound_request_duration_seconds_count{namespace=\"$namespace\"}[1m])) by (type,url)",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{type}}: {{url}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Outbound Latency (ms)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 18,
+        "y": 15
+      },
+      "id": 15,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.1.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by (new_code) (\n  label_replace(\n    rate(outbound_request_duration_seconds_count{namespace=\"$namespace\",type=~\"event|notification\",code=~'3..|4..|5..'}[$__range]),\n    \"new_code\",\n    \"${1}xx\",\n    \"code\",\n    \"(^\\\\d).+\"\n  )\n) / \nscalar(sum(rate(outbound_request_duration_seconds_count{namespace=\"$namespace\",type=~\"event|notification\"}[$__range]))) * 100",
+          "instant": false,
+          "legendFormat": "{{new_code}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Outbound Error codes percentage",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Name",
+          "sortDesc": false
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sum by (path) (increase(inbound_request_duration_seconds_count{namespace=\"$namespace\",path=~\"$path\"}[$__rate_interval]))",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{method}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Inbound RPM per API",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Name",
+          "sortDesc": false
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "avg(rate(inbound_request_duration_seconds_sum{namespace=\"$namespace\",path=~\"$path\"}[1m])) by (path) / avg(rate(inbound_request_duration_seconds_count{namespace=\"$namespace\",path=~\"$path\"}[1m])) by (path)",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{path}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Inbound Latency per API (ms)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 39,
+  "tags": [
+    "account"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "sa-prod",
+          "value": "sa-prod"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "label_values(go_info{namespace=~\"sa-prod|account-dev|account-pre\"},namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(go_info{namespace=~\"sa-prod|account-dev|account-pre\"},namespace)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "allValue": ".+",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "label_values(inbound_request_duration_seconds_count,path)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "path",
+        "multi": false,
+        "name": "path",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(inbound_request_duration_seconds_count,path)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "Mimir",
+          "value": "$datasource"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Account App Dashboard",
+  "uid": "account_app_dashboard",
+  "version": 15,
+  "weekStart": ""
+}

--- a/mixins/dashboards/golang-dashboard.json
+++ b/mixins/dashboards/golang-dashboard.json
@@ -1,0 +1,1253 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "A quickstart to setup the Prometheus Go runtime exporter with preconfigured dashboards, alerting rules, and recording rules.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "gnetId": 14061,
+  "graphTooltip": 0,
+  "id": 51,
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "account"
+      ],
+      "targetBlank": false,
+      "title": "Account dashboards",
+      "type": "dashboards"
+    }
+  ],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "Average total bytes of memory reserved across all process instances of a job.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "avg by(job)(go_memstats_sys_bytes{namespace=\"$namespace\",job=~\"$job\",instance=~\"$instance\"})",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total Reserved Memory",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {},
+      "description": "Average stack memory usage across all instances of a job.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "avg by (job) (go_memstats_stack_sys_bytes{namespace=\"$namespace\", job=~\"$job\", instance=~\"$instance\"})",
+          "interval": "",
+          "legendFormat": "{{job}}: stack inuse (avg)",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Stack Memory Use",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "Average memory reservations by the runtime, not for stack or heap, across all instances of a job.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 26,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "avg by (job)(go_memstats_mspan_sys_bytes{namespace=\"$namespace\", job=~\"$job\", instance=~\"$instance\"})",
+          "interval": "",
+          "legendFormat": "{{instance}}: mspan (avg)",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "avg by (job)(go_memstats_mcache_sys_bytes{namespace=\"$namespace\", job=~\"$job\", instance=~\"$instance\"})",
+          "interval": "",
+          "legendFormat": "{{instance}}: mcache (avg)",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "avg by (job)(go_memstats_buck_hash_sys_bytes{namespace=\"$namespace\", job=~\"$job\", instance=~\"$instance\"})",
+          "interval": "",
+          "legendFormat": "{{instance}}: buck hash (avg)",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "avg by (job)(go_memstats_gc_sys_bytes{namespace=\"$namespace\", job=~\"$job\", instance=~\"$instance\"})",
+          "interval": "",
+          "legendFormat": "{{job}}: gc (avg)",
+          "range": true,
+          "refId": "F"
+        }
+      ],
+      "title": "Other Memory Reservations",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "Average memory reserved, and actually in use, by the heap, across all instances of a job.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "avg by (job)(go_memstats_heap_sys_bytes{namespace=\"$namespace\", job=~\"$job\", instance=~\"$instance\"})",
+          "interval": "",
+          "legendFormat": "{{job}}: heap reserved (avg)",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "avg by (job)(go_memstats_heap_inuse_bytes{namespace=\"$namespace\", job=~\"$job\", instance=~\"$instance\"})",
+          "interval": "",
+          "legendFormat": "{{job}}: heap in use (avg)",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "avg by (job)(go_memstats_heap_alloc_bytes{job=~\"tns_app\",instance=~\".*\"})",
+          "interval": "",
+          "legendFormat": "{{job}}: heap alloc (avg)",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "avg by (job)(go_memstats_heap_idle_bytes{job=~\"tns_app\",instance=~\".*\"})",
+          "interval": "",
+          "legendFormat": "{{job}}: heap idle (avg)",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "avg by (job)(go_memstats_heap_released_bytes{job=~\"tns_app\",instance=~\".*\"})",
+          "interval": "",
+          "legendFormat": "{{job}}: heap released (avg)",
+          "refId": "E"
+        }
+      ],
+      "title": "Heap Memory",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "Average allocation rate in bytes per second, across all instances of a job.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "always",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "avg by (job)(rate(go_memstats_alloc_bytes_total{namespace=\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "interval": "",
+          "legendFormat": "{{job}}: bytes malloced/s (avg)",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Allocation Rate, Bytes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "Average rate of heap object allocation, across all instances of a job.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "rate(go_memstats_mallocs_total{namespace=\"$namespace\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])",
+          "interval": "",
+          "legendFormat": "{{job}}: obj mallocs/s (avg)",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Heap Object Allocation Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "Average number of live memory objects across all instances of a job.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "avg by(job)(go_memstats_mallocs_total{namespace=\"$namespace\", job=~\"$job\", instance=~\"$instance\"} - go_memstats_frees_total{namespace=\"$namespace\", job=~\"$job\", instance=~\"$instance\"})",
+          "interval": "",
+          "legendFormat": "{{job}}: object count (avg)",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Number of Live Objects",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "Average number of goroutines across instances of a job.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "avg by (job)(go_goroutines{namespace=\"$namespace\", job=~\"$job\", instance=~\"$instance\"})",
+          "interval": "",
+          "legendFormat": "{{job}}: goroutine count (avg)",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Goroutines",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "avg by (job)(go_gc_duration_seconds{quantile=\"0\", namespace=\"$namespace\", job=~\"$job\", instance=~\"$instance\"})",
+          "interval": "",
+          "legendFormat": "{{job}}: min gc time (avg)",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "avg by (job)(go_gc_duration_seconds{quantile=\"1\", namespace=\"$namespace\", job=~\"$job\", instance=~\"$instance\"})",
+          "interval": "",
+          "legendFormat": "{{job}}: max gc time (avg)",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "GC min & max duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "The number used bytes at which the runtime plans to perform the next GC, averaged across all instances of a job.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "id": 27,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "avg by (job)(go_memstats_next_gc_bytes{namespace=\"$namespace\", job=~\"$job\", instance=~\"$instance\"})",
+          "interval": "",
+          "legendFormat": "{{job}} next gc bytes (avg)",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Next GC, Bytes",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "revision": 1,
+  "schemaVersion": 39,
+  "tags": [
+    "go",
+    "golang",
+    "account"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "sa-prod",
+          "value": "sa-prod"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "label_values(go_info{namespace=~\"sa-prod|account-dev|account-pre\"},namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(go_info{namespace=~\"sa-prod|account-dev|account-pre\"},namespace)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "Mimir",
+          "value": "$datasource"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "account-workspace-service",
+          "value": "account-workspace-service"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "label_values(go_info{namespace=\"$namespace\"},job)",
+        "description": "job",
+        "hide": 0,
+        "includeAll": true,
+        "label": "job",
+        "multi": false,
+        "name": "job",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(go_info{namespace=\"$namespace\"},job)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "label_values(go_info{namespace=\"$namespace\"},instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "instance",
+        "multi": false,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(go_info{namespace=\"$namespace\"},instance)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Account Golang",
+  "uid": "account_golang",
+  "version": 10,
+  "weekStart": ""
+}

--- a/templates/dashboards.yaml
+++ b/templates/dashboards.yaml
@@ -1,0 +1,26 @@
+{{- $currentScope := .Values.global.dashboards }}
+{{- if and $currentScope.enabled .Values.global.serviceMonitor.enabled}}
+{{ range $path, $_ :=  $.Files.Glob  "mixins/dashboards/*.json" }}
+{{ $file := $path | base }}
+{{ $name := print ($file | trimSuffix ".json")  "-dashboard" }}
+{{- with $currentScope}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+data:
+  {{ $file }}: |-
+{{ $.Files.Get $path | indent 4 }}
+---
+{{- end }}
+{{ end }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -8,6 +8,21 @@ global:
   env: "prod"
   serviceMonitor:
     enabled: false
+  # Dashboard configuration for deploying Grafana dashboards for Account
+  dashboards:
+    # -- If enabled, Grafana dashboards are deployed
+    enabled: false
+    # -- Annotations to add to the Grafana dashboard ConfigMap
+    # Note: If using with middleware observability platform, annotation should be provided to place dashboards in proper folder.
+    # From observability chart, value from grafana.sidecar.dashboards.folderAnnotation is a
+    # "key" for annotation, and value is a name of folder which will be created in Grafana UI for Account dashboards.
+    annotations: {}
+    # -- Labels to add to the Grafana dashboard ConfigMap
+    # Note: If using with middleware observability platform, labels should be provided to discovery
+    # dashboards and upload them to grafana. From observability chart, value from grafana.sidecar.dashboards.label is a key,
+    # and grafana.sidecar.dashboards.labelValue is a value for that label.
+    # So, label should look like grafana.sidecar.dashboards.label:grafana.sidecar.dashboards.labelValue
+    labels: {}
   # First login password will be changed during first login.
   init_admin_password: 111
   #######  PostgreSQL  ########
@@ -96,6 +111,9 @@ global:
     persistantVolumeClaimName: "workspace-pvc"
     persistantVolumeClaimCreate: true
     persistantVolumeClaimShareDir: "avatars"
+    content_security_policy:
+      urls:
+        # - https://doc.corezoid.com
     email_confirm: true
     autoscaling:
       enabled: true
@@ -388,6 +406,9 @@ global:
     #               - arm64
     workspace:
       port: 8080
+      ##  @param .Values.global.account.workspace.portMetrics Define port for metrics, default - 9100.
+      ## Will set in config file if .Values.global.serviceMonitor.enable set true
+      portMetrics: 9100
       persistantVolumeClaimName: "workspace-pvc"
       persistantVolumeClaimCreate: true
       config:
@@ -422,6 +443,9 @@ global:
           eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/mw-dev-workspace-1-euw1-stripe-dev-role
     auth:
       port: 8080
+      ##  @param .Values.global.account.auth.portMetrics Define port for metrics, default - 9100.
+      ## Will set in config file if .Values.global.serviceMonitor.enable set true
+      portMetrics: 9100
       autoscaling:
         enabled: true
         minReplicas: 2


### PR DESCRIPTION
## Chart 0.2.11 [SingleSpace 3.12.5] - 2024-09-30.
### Helm changes
- Applications versions:
  - auth - 3.12.5
  - workspace - 3.12.5
  - frontend - 3.12.4
  - ingress - 0.1.2
- Add parameter `content_security_policy` in values file.
- The minimum number of characters in the password has been increased


## Chart 0.2.10 [SingleSpace 3.10.0] - 2024-07-31.
### Helm changes
- Applications versions:
    - auth - 3.10.6
    - workspace - 3.10.6
    - frontend - 3.10.0
    - ingress - 0.1.2
- Add parameter `portMetrics` in values file, using for define port for metrics
- Add monitoring for `auth`
- Update monitoring manifest for `workspace`

## Chart 0.2.9 [SingleSpace 3.10.0] - 2024-07-29.
### Helm changes
- New applications versions:
    - auth - 3.10.6
    - workspace - 3.10.6
    - frontend - 3.10.0
    - ingress - 0.1.2
- Remove hardcode registry domain from sub-charts. Switch to `{{ .Values.global.imageRegistry }}`