### PR TITLE
New release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Chart 0.2.13 [SingleSpace 3.13.0] - 2024-10-10.
+### Helm changes
+- Applications versions:
+  - auth - 3.13.1
+  - workspace - 3.13.1
+  - frontend - 3.13.0
+  - ingress - 0.1.2
+- Add `liveness` and `readiness` for `auth` and `workspace` applications
+
 
 ## Chart 0.2.12 [SingleSpace 3.13.0] - 2024-10-08.
 ### Helm changes
@@ -13,8 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - workspace - 3.13.1
   - frontend - 3.13.0
   - ingress - 0.1.2
-- cookie_same_site attribute added to the config (optional)
-- new imageRegistry url
+- Added `cookie_same_site` attribute to the config (optional)
+- New `imageRegistry` url
 
 ### Improvements / New Features
 #### 1. client APIs added: CRUD operations for groups and API keys

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,14 +3,14 @@ name: singlespace
 description: A Helm chart for Account
 icon: https://account.corezoid.com/static/logo.svg
 type: application
-version: 0.2.12
+version: 0.2.13
 appVersion: 3.13.0
 dependencies:
   - name: account-auth
-    version: 0.1.16
+    version: 0.1.17
   - name: account-frontend
     version: 0.1.14
   - name: account-ingress
     version: 0.1.2
   - name: account-workspace
-    version: 0.1.16
+    version: 0.1.17

--- a/charts/account-auth/Chart.yaml
+++ b/charts/account-auth/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: account-auth
 description: A Helm chart for Account Auth
 type: application
-version: 0.1.16
+version: 0.1.17
 appVersion: 3.13.1

--- a/charts/account-auth/templates/_helpers.tpl
+++ b/charts/account-auth/templates/_helpers.tpl
@@ -87,3 +87,35 @@ Image url
 {{- end }}
 {{- end }}
 
+
+{{/*
+Liveness
+*/}}
+{{- define "account.auth.liveness" -}}
+livenessProbe:
+  httpGet:
+    scheme: HTTP
+    path: {{ .Values.appAuthLivenessPath }}
+    port: {{ include "account.auth.portHttpName" . }}
+  initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+  periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+  timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+  successThreshold: {{ .Values.livenessProbe.successThreshold }}
+  failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+{{- end }}
+
+{{/*
+Readiness
+*/}}
+{{- define "account.auth.readiness" -}}
+readinessProbe:
+  httpGet:
+    scheme: HTTP
+    path: {{ .Values.appAuthReadinessPath }}
+    port: {{ include "account.auth.portHttpName" . }}
+  initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+  periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+  timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+  successThreshold: {{ .Values.readinessProbe.successThreshold }}
+  failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+{{- end }}

--- a/charts/account-auth/templates/deployment.yaml
+++ b/charts/account-auth/templates/deployment.yaml
@@ -81,6 +81,8 @@ spec:
               containerPort: {{ include "account.auth.portMetricsNumber" . }}
               protocol: {{ include "account.auth.portProtocol" . }}
             {{- end }}
+          {{- include "account.auth.liveness" . | nindent 10 }}
+          {{- include "account.auth.readiness" . | nindent 10 }}
           {{- with $auth_data.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/account-auth/values.yaml
+++ b/charts/account-auth/values.yaml
@@ -5,3 +5,19 @@ image:
 
 configPath: "/opt/conf"
 configName: "config.yml"
+appAuthLivenessPath: "/liveness"
+appAuthReadinessPath: "/readiness"
+
+livenessProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 3
+
+readinessProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 3

--- a/charts/account-workspace/Chart.yaml
+++ b/charts/account-workspace/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: account-workspace
 description: A Helm chart for WorkSpace
 type: application
-version: 0.1.16
+version: 0.1.17
 appVersion: 3.13.1

--- a/charts/account-workspace/templates/_helpers.tpl
+++ b/charts/account-workspace/templates/_helpers.tpl
@@ -55,7 +55,7 @@ application: {{ include "module.workspace.name" . }}
 {{- end }}
 
 {{- define "account.workspace.portHttpName" -}}
-{{- printf "%s" "http" }}
+http
 {{- end }}
 
 {{- define "account.workspace.portProtocol" -}}
@@ -87,31 +87,33 @@ Image url
 {{- end }}
 
 {{/*
+Liveness
+*/}}
+{{- define "account.workspace.liveness" -}}
+livenessProbe:
+  httpGet:
+    scheme: HTTP
+    path: {{ .Values.appAuthLivenessPath }}
+    port: {{ include "account.workspace.portHttpName" . }}
+  initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+  periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+  timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+  successThreshold: {{ .Values.livenessProbe.successThreshold }}
+  failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+{{- end }}
+
+{{/*
 Readiness
 */}}
 {{- define "account.workspace.readiness" -}}
 readinessProbe:
   httpGet:
     scheme: HTTP
-    path: /api/sa/1.0/check/readiness
-    port: {{ .Values.global.account.workspace.port }}
-  initialDelaySeconds: 10
-  periodSeconds: 5
-  timeoutSeconds: 5
-  successThreshold: 1
-  failureThreshold: 3
-{{- end }}
-
-{{/*
-Liveness
-*/}}
-{{- define "account.workspace.liveness" -}}
-livenessProbe:
-  tcpSocket:
-    port: {{ .Values.global.account.workspace.port }}
-  initialDelaySeconds: 15
-  periodSeconds: 10
-  timeoutSeconds: 5
-  successThreshold: 1
-  failureThreshold: 3
+    path: {{ .Values.appAuthReadinessPath }}
+    port: {{ include "account.workspace.portHttpName" . }}
+  initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+  periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+  timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+  successThreshold: {{ .Values.readinessProbe.successThreshold }}
+  failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
 {{- end }}

--- a/charts/account-workspace/templates/deployment.yaml
+++ b/charts/account-workspace/templates/deployment.yaml
@@ -75,6 +75,8 @@ spec:
               containerPort: {{ include "account.workspace.portMetricsNumber" . }}
               protocol: {{ include "account.workspace.portProtocol" . }}
             {{- end }}
+          {{- include "account.workspace.liveness" . | nindent 10 }}
+          {{- include "account.workspace.readiness" . | nindent 10 }}
           {{- with $workspace_data.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/account-workspace/values.yaml
+++ b/charts/account-workspace/values.yaml
@@ -5,3 +5,19 @@ image:
 
 configPath: "/opt/conf"
 configName: "config.yml"
+appAuthLivenessPath: "/liveness"
+appAuthReadinessPath: "/readiness"
+
+livenessProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 3
+
+readinessProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 3


### PR DESCRIPTION
## Chart 0.2.13 [SingleSpace 3.13.0] - 2024-10-10.
### Helm changes
- Applications versions:
  - auth - 3.13.1
  - workspace - 3.13.1
  - frontend - 3.13.0
  - ingress - 0.1.2
- Add `liveness` and `readiness` for `auth` and `workspace` applications