### PR TITLE
Update Account Helm chart to version 0.2.39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to this project will be documented in this file.
 
+## Chart 0.2.39 [Account 3.29.5] - 2026-07-07
+### Application Versions
+- **account-frontend**: 3.28.0
+- **account-auth**: 3.29.5
+- **account-workspace**: 3.29.5
+
+#### New Features
+- Personalized user search ranking based on selection history
+- Improved transliteration support for user search (Cyrillic/Latin spelling variants)
+- Task log archival: optional long-term retention of task history in object storage
+- OAuth2 Dynamic Client Registration (DCR) and OIDC discovery
+- AI token management API (LiteLLM integration)
+- Stripe invoices displayed on the Payments page
+- Workspace ownership transfer via checkbox
+- User timezone settings
+- Suggest selection from a list of authorized profiles
+
+#### Enhancements
+- Improved search ranking accuracy and reduced false matches from transliteration
+- TLS support for Redis/ElastiCache in auth and workspace services
+- Enforced group owner assignment across all environments
+
+#### Bug Fixes
+- Fixed incorrect search results caused by transliteration artifacts
+- Fixed OAuth2 token response format and JWT issuance for cloud clients
+- Fixed license retention permissions and settings issues
+- Fixed incorrect user search results by email in Simulator
+- Fixed Keycloak login display (username instead of email)
+- Fixed user permission transfer issue in the instance users list
+- Fixed AI avatar generation failure with text-containing photos
+- Fixed missing search indexing for newly registered users
+
 ## Chart 0.2.37 [Account 3.26.4] - 2026-05-22
 ### Application Versions
 - **account-frontend**: 3.26.2

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,16 +3,16 @@ name: singlespace
 description: A Helm chart for Account
 icon: https://account.corezoid.com/static/logo.svg
 type: application
-version: 0.2.37
-appVersion: 3.26.4
+version: 0.2.39
+appVersion: 3.29.5
 dependencies:
   - name: account-auth
-    version: 0.1.40
+    version: 0.1.41
   - name: account-frontend
-    version: 0.1.35
+    version: 0.1.36
   - name: account-ingress
     version: 0.1.2
   - name: account-workspace
-    version: 0.1.40
+    version: 0.1.41
   - name: account-valkey
     version: 0.2.0

--- a/charts/account-auth/Chart.yaml
+++ b/charts/account-auth/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: account-auth
 description: A Helm chart for Account Authentication Service
 type: application
-version: 0.1.40
-appVersion: 3.26.4
+version: 0.1.41
+appVersion: 3.29.5
 keywords:
   - authentication
   - authorization

--- a/charts/account-frontend/Chart.yaml
+++ b/charts/account-frontend/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 name: account-frontend
 description: A Helm chart for Account Frontend
 type: application
-version: 0.1.35
-appVersion: 3.26.2
+version: 0.1.36
+appVersion: 3.28.0

--- a/charts/account-frontend/templates/configmap.yaml
+++ b/charts/account-frontend/templates/configmap.yaml
@@ -80,6 +80,26 @@ data:
       }
       {{- end }}
 
+      # Allowed origins for OAuth 2.0 XHR endpoints (/oauth2/*). Localhost
+      # with any port is permitted for MCP Inspector / Claude Desktop and
+      # similar tools running on the developer's machine. Production MCP
+      # clients on real domains can be added via:
+      #   global.account.oauth2.cors_origins: ["https://example.com", ...]
+      # If the Origin does not match, the map returns "" and nginx drops
+      # the Access-Control-Allow-Origin header entirely, so the browser
+      # blocks the request.
+      map $http_origin $oauth2_cors_origin {
+        default "";
+        "~^http://localhost(:[0-9]+)?$"     $http_origin;
+        "~^http://127\.0\.0\.1(:[0-9]+)?$"  $http_origin;
+        "~^http://\[::1\](:[0-9]+)?$"       $http_origin;
+        {{- if .Values.global.account.oauth2 }}
+        {{- range .Values.global.account.oauth2.cors_origins }}
+        "{{ . }}" "{{ . }}";
+        {{- end }}
+        {{- end }}
+      }
+
       server_tokens   off;
       # disable buffering
       proxy_buffering off;
@@ -321,13 +341,63 @@ data:
         add_header Content-Security-Policy "default-src 'self' blob: 'unsafe-inline' 'unsafe-eval' data: {{- range .Values.global.account.content_security_policy.urls }} {{.}}{{- end }} https://unpkg.com wss://*.{{ .Values.global.env }}.{{ .Values.global.domain }} https://{{ .Values.global.account.subDomain}}.{{ .Values.global.domain }}  https://*.control.events https://img.icons8.com/ https://www.google-analytics.com https://fonts.gstatic.com https://www.googletagmanager.com https://*.{{ .Values.global.env }}.{{ .Values.global.domain }} https://github.com https://www.facebook.com https://appleid.apple.com https://*.ngrok-free.app https://*.google.com https://stats.g.doubleclick.net https://fonts.googleapis.com https://*.google.com.ua https://*.shopify.com https://shopify.com https://*.googleusercontent.com https://*.simulator.company; frame-ancestors 'self' https://{{ .Values.global.account.subDomain}}.{{ .Values.global.domain }} https://*.control.events https://*.simulator.company {{- range .Values.global.account.content_security_policy.urls }} {{.}}{{- end }};";
       }
 
+      # RFC 8414 authorization-server metadata. Served as a static file from
+      # the SPA root, so we override the global default_type (octet-stream)
+      # with application/json — strict OAuth / MCP clients refuse to parse
+      # the document otherwise.
+      # CORS is open because the document is public and MCP/OAuth clients
+      # fetch it from arbitrary origins (e.g. localhost MCP Inspector).
+      location = /.well-known/oauth-authorization-server {
+        default_type application/json;
+        add_header Access-Control-Allow-Origin "*" always;
+        add_header Access-Control-Allow-Methods "GET, OPTIONS" always;
+        add_header Access-Control-Allow-Headers "Authorization, Content-Type, mcp-protocol-version" always;
+        add_header Access-Control-Max-Age "86400" always;
+        if ($request_method = OPTIONS) {
+          return 204;
+        }
+        {{ include "common.security.headers" . }}
+        {{ include "common.csp.policy" . }}
+        try_files $uri =404;
+      }
+
+      # openid-configuration is a separate spec and is not served by this
+      # host; without an explicit location it falls through to `location /`
+      # and clients receive the SPA's index.html as if it were JSON.
+      location = /.well-known/openid-configuration {
+        {{ include "common.security.headers" . }}
+        {{ include "common.csp.policy" . }}
+        return 404;
+      }
+
       location / {
         {{ include "common.security.headers" . }}
         {{ include "common.csp.policy" . }}
         try_files $uri /index.html;
       }
 
+      # OAuth 2.0 endpoints called as XHR from browser-based MCP / OAuth
+      # clients (Inspector, Claude Desktop, etc.) — needs CORS. Allowed
+      # origins are gated by the $oauth2_cors_origin map above (localhost
+      # only by default; extend via global.account.oauth2.cors_origins).
+      # Declared with `^~` so it wins over the regex location below
+      # regardless of file order.
       {{- if .Values.global.account.config.one_app }}
+      location ^~ /oauth2/ {
+        add_header Access-Control-Allow-Origin $oauth2_cors_origin always;
+        add_header Vary Origin always;
+        add_header Access-Control-Allow-Methods "GET, POST, OPTIONS" always;
+        add_header Access-Control-Allow-Headers "Authorization, Content-Type, mcp-protocol-version" always;
+        add_header Access-Control-Expose-Headers "WWW-Authenticate" always;
+        add_header Access-Control-Max-Age "86400" always;
+        if ($request_method = OPTIONS) {
+          return 204;
+        }
+        proxy_pass http://{{ include "account.workspace.service.name" . }}:{{ .Values.global.account.workspace.port | default 80}};
+        add_header Cache-Control "no-cache, must-revalidate";
+        {{ include "common.security.headers" . }}
+        {{ include "common.csp.policy" . }}
+      }
       location ~ ^/(client|public|face|webhook|api|auth|oauth2|download|pmi_lms) {
         proxy_pass http://{{ include "account.workspace.service.name" . }}:{{ .Values.global.account.workspace.port | default 80}};
         add_header Cache-Control "no-cache, must-revalidate";
@@ -335,6 +405,21 @@ data:
         {{ include "common.csp.policy" . }}
       }
       {{- else }}
+      location ^~ /oauth2/ {
+        add_header Access-Control-Allow-Origin $oauth2_cors_origin always;
+        add_header Vary Origin always;
+        add_header Access-Control-Allow-Methods "GET, POST, OPTIONS" always;
+        add_header Access-Control-Allow-Headers "Authorization, Content-Type, mcp-protocol-version" always;
+        add_header Access-Control-Expose-Headers "WWW-Authenticate" always;
+        add_header Access-Control-Max-Age "86400" always;
+        if ($request_method = OPTIONS) {
+          return 204;
+        }
+        proxy_pass http://{{ include "account.auth.service.name" . }}:{{ .Values.global.account.auth.port | default 80}};
+        add_header Cache-Control "no-cache, must-revalidate";
+        {{ include "common.security.headers" . }}
+        {{ include "common.csp.policy" . }}
+      }
       location ~ ^/(api|auth|oauth2|download|pmi_lms) {
         proxy_pass http://{{ include "account.auth.service.name" . }}:{{ .Values.global.account.auth.port | default 80}};
         add_header Cache-Control "no-cache, must-revalidate";

--- a/charts/account-workspace/Chart.yaml
+++ b/charts/account-workspace/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: account-workspace
 description: A Helm chart for Account Workspace Service
 type: application
-version: 0.1.40
-appVersion: 3.26.4
+version: 0.1.41
+appVersion: 3.29.5
 keywords:
   - workspace
   - account-management


### PR DESCRIPTION
- Updated root chart version from 0.2.37 to 0.2.39
- Updated appVersion from 3.26.4 to 3.29.5
- Updated account-auth subchart version from 0.1.40 to 0.1.41 (appVersion 3.29.5)
- Updated account-frontend subchart version from 0.1.35 to 0.1.36 (appVersion 3.28.0)
- Updated account-workspace subchart version from 0.1.40 to 0.1.41 (appVersion 3.29.5)
- Updated CHANGELOG.md with new release entry
- Enable CORS on OAuth 2.0 endpoints for MCP/browser-based OAuth clients