### PR TITLE
Update Account Helm chart to version 0.2.41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## Chart 0.2.41 [Account 3.29.6] - 2026-07-16
+### Application Versions
+- **account-frontend**: 3.28.0
+- **account-auth**: 3.29.6
+- **account-workspace**: 3.29.6
+
+#### Bug Fixes
+- Hotfix for account-auth and account-workspace
+
 ## Chart 0.2.39 [Account 3.29.5] - 2026-07-07
 ### Application Versions
 - **account-frontend**: 3.28.0

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,16 +3,16 @@ name: singlespace
 description: A Helm chart for Account
 icon: https://account.corezoid.com/static/logo.svg
 type: application
-version: 0.2.39
-appVersion: 3.29.5
+version: 0.2.41
+appVersion: 3.29.6
 dependencies:
   - name: account-auth
-    version: 0.1.41
+    version: 0.1.42
   - name: account-frontend
     version: 0.1.36
   - name: account-ingress
     version: 0.1.2
   - name: account-workspace
-    version: 0.1.41
+    version: 0.1.42
   - name: account-valkey
     version: 0.2.0

--- a/charts/account-auth/Chart.yaml
+++ b/charts/account-auth/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: account-auth
 description: A Helm chart for Account Authentication Service
 type: application
-version: 0.1.41
-appVersion: 3.29.5
+version: 0.1.42
+appVersion: 3.29.6
 keywords:
   - authentication
   - authorization

--- a/charts/account-workspace/Chart.yaml
+++ b/charts/account-workspace/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: account-workspace
 description: A Helm chart for Account Workspace Service
 type: application
-version: 0.1.41
-appVersion: 3.29.5
+version: 0.1.42
+appVersion: 3.29.6
 keywords:
   - workspace
   - account-management


### PR DESCRIPTION
- Updated root chart version from 0.2.39 to 0.2.41
- Updated appVersion from 3.29.5 to 3.29.6
- Updated account-auth subchart version from 0.1.41 to 0.1.42 (appVersion 3.29.6)
- Updated account-workspace subchart version from 0.1.41 to 0.1.42 (appVersion 3.29.6)
- Updated CHANGELOG.md with new release entry